### PR TITLE
fix query encoding bug

### DIFF
--- a/lib/AWS/Lambda/PSGI.pm
+++ b/lib/AWS/Lambda/PSGI.pm
@@ -4,7 +4,6 @@ use utf8;
 use strict;
 use warnings;
 use URI::Escape;
-use WWW::Form::UrlEncoded qw/build_urlencoded/;
 use Plack::Util;
 use bytes ();
 use MIME::Base64;
@@ -68,7 +67,17 @@ sub format_input {
         %{$payload->{queryStringParameters} // {}},
         %{$payload->{multiValueQueryStringParameters} // {}},
     };
-    $env->{QUERY_STRING} = build_urlencoded($query);
+    my @params;
+    while (my ($key, $value) = each %$query) {
+        if (ref($value) eq 'ARRAY') {
+            for my $v (@$value) {
+                push @params, "$key=$v";
+            }
+        } else {
+            push @params, "$key=$value";
+        }
+    }
+    $env->{QUERY_STRING} = join '&', @params;
 
     # merge headers and multiValueHeaders
     my $headers = {

--- a/t/20_psgi.t
+++ b/t/20_psgi.t
@@ -194,4 +194,21 @@ subtest "EUC-JP encoded response" => sub {
     diag encode_json $res;
 };
 
+subtest "query string enconding" => sub {
+    my $input = decode_json(slurp("$FindBin::Bin/testdata/apigateway-get-request.json"));
+    $input->{queryStringParameters} = {
+        "gif+ref+" => "",
+    };
+    $input->{multiValueQueryStringParameters} = {
+        "gif+ref+" => [""],
+    };
+    my $output = $app->format_input($input);
+    my $req = Plack::Request->new($output);
+    is $req->method, 'GET', 'method';
+    is $req->content, '', 'content';
+    is $req->request_uri, '/foo%20/bar', 'request uri';
+    is $req->path_info, '/foo /bar', 'path info';
+    is $req->query_string, 'gif+ref+=', 'query string';
+};
+
 done_testing;


### PR DESCRIPTION
want `path?gif+ref=`, but got `path?gif%2Bref%2B=`.
