### PR TITLE
fix useless error messages.

### DIFF
--- a/lib/AWS/Lambda/Bootstrap.pm
+++ b/lib/AWS/Lambda/Bootstrap.pm
@@ -86,7 +86,7 @@ sub lambda_next {
     my $self = shift;
     my $resp = $self->{http}->get($self->{next_event_url});
     if (!$resp->{success}) {
-        die 'failed to retrieve the next event: $resp->{status} $resp->{reason}';
+        die "failed to retrieve the next event: $resp->{status} $resp->{reason}";
     }
     my $h = $resp->{headers};
     my $payload = decode_json($resp->{content});
@@ -143,7 +143,7 @@ sub lambda_init_error {
         }),
     });
     if (!$resp->{success}) {
-        die 'failed to send error of execution: $resp->{status} $resp->{reason}';
+        die "failed to send error of execution: $resp->{status} $resp->{reason}";
     }
 }
 

--- a/lib/AWS/Lambda/Bootstrap.pm
+++ b/lib/AWS/Lambda/Bootstrap.pm
@@ -108,7 +108,7 @@ sub lambda_response {
         content => encode_json($response),
     });
     if (!$resp->{success}) {
-        die 'failed to response of execution: $resp->{status} $resp->{reason}';
+        die "failed to response of execution: $resp->{status} $resp->{reason}";
     }
 }
 
@@ -126,7 +126,7 @@ sub lambda_error {
         }),
     });
     if (!$resp->{success}) {
-        die 'failed to send error of execution: $resp->{status} $resp->{reason}';
+        die "failed to send error of execution: $resp->{status} $resp->{reason}";
     }
 }
 

--- a/t/10_lambda_next.t
+++ b/t/10_lambda_next.t
@@ -30,6 +30,8 @@ my $app_server = Test::TCP->new(
             ]
         });
     },
+    wait_port_retry => 40,
+    wait_port_sleep => 0.1,
 );
 
 my $bootstrap = AWS::Lambda::Bootstrap->new(

--- a/t/11_lambda_response.t
+++ b/t/11_lambda_response.t
@@ -31,6 +31,8 @@ my $app_server = Test::TCP->new(
             $res->finalize;
         });
     },
+    wait_port_retry => 40,
+    wait_port_sleep => 0.1,
 );
 
 my $bootstrap = AWS::Lambda::Bootstrap->new(

--- a/t/12_lambda_error.t
+++ b/t/12_lambda_error.t
@@ -31,6 +31,8 @@ my $app_server = Test::TCP->new(
             $res->finalize;
         });
     },
+    wait_port_retry => 40,
+    wait_port_sleep => 0.1,
 );
 
 my $bootstrap = AWS::Lambda::Bootstrap->new(

--- a/t/13_lambda_init_error.t
+++ b/t/13_lambda_init_error.t
@@ -31,6 +31,8 @@ my $app_server = Test::TCP->new(
             $res->finalize;
         });
     },
+    wait_port_retry => 40,
+    wait_port_sleep => 0.1,
 );
 
 my $bootstrap = AWS::Lambda::Bootstrap->new(


### PR DESCRIPTION
> http://www.cpantesters.org/cpan/report/a779ffe6-4301-11e9-bf31-80c71e9d5857
> failed to retrieve the next event: $resp->{status} $resp->{reason} at /tmp/build/AWS-Lambda-0.0.1-0/blib/lib/AWS/Lambda/Bootstrap.pm line 89.

I want more error info...