### PR TITLE
Africa (Cape Town) Region (af-south-1 ) is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This package makes it easy to run AWS Lambda Functions written in Perl.
 The Layer ARN list is here.
 
 - Perl 5.30
+    - `arn:aws:lambda:af-south-1:445285296882:layer:perl-5-30-runtime:1`
     - `arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-30-runtime:8`
     - `arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-30-runtime:8`
     - `arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-30-runtime:8`
@@ -63,6 +64,7 @@ The Layer ARN list is here.
     - `arn:aws:lambda:us-west-1:445285296882:layer:perl-5-30-runtime:8`
     - `arn:aws:lambda:us-west-2:445285296882:layer:perl-5-30-runtime:8`
 - Perl 5.28
+    - `arn:aws:lambda:af-south-1:445285296882:layer:perl-5-28-runtime:1`
     - `arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-28-runtime:7`
     - `arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-28-runtime:14`
     - `arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-28-runtime:14`
@@ -81,6 +83,7 @@ The Layer ARN list is here.
     - `arn:aws:lambda:us-west-1:445285296882:layer:perl-5-28-runtime:14`
     - `arn:aws:lambda:us-west-2:445285296882:layer:perl-5-28-runtime:14`
 - Perl 5.26
+    - `arn:aws:lambda:af-south-1:445285296882:layer:perl-5-26-runtime:1`
     - `arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-26-runtime:8`
     - `arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-26-runtime:15`
     - `arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-26-runtime:15`
@@ -178,6 +181,7 @@ Now, you can use [Paws](https://metacpan.org/pod/Paws) to call AWS API from your
 The Layer ARN list is here.
 
 - Perl 5.30
+    - `arn:aws:lambda:af-south-1:445285296882:layer:perl-5-30-paws:1`
     - `arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-30-paws:5`
     - `arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-30-paws:5`
     - `arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-30-paws:5`
@@ -196,6 +200,7 @@ The Layer ARN list is here.
     - `arn:aws:lambda:us-west-1:445285296882:layer:perl-5-30-paws:5`
     - `arn:aws:lambda:us-west-2:445285296882:layer:perl-5-30-paws:5`
 - Perl 5.28
+    - `arn:aws:lambda:af-south-1:445285296882:layer:perl-5-28-paws:1`
     - `arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-28-paws:4`
     - `arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-28-paws:4`
     - `arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-28-paws:4`
@@ -214,6 +219,7 @@ The Layer ARN list is here.
     - `arn:aws:lambda:us-west-1:445285296882:layer:perl-5-28-paws:4`
     - `arn:aws:lambda:us-west-2:445285296882:layer:perl-5-28-paws:4`
 - Perl 5.26
+    - `arn:aws:lambda:af-south-1:445285296882:layer:perl-5-26-paws:1`
     - `arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-26-paws:5`
     - `arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-26-paws:5`
     - `arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-26-paws:5`

--- a/author/regions.txt
+++ b/author/regions.txt
@@ -1,3 +1,4 @@
+af-south-1
 ap-east-1
 ap-northeast-1
 ap-northeast-2

--- a/lib/AWS/Lambda.pm
+++ b/lib/AWS/Lambda.pm
@@ -95,6 +95,8 @@ The Layer ARN list is here.
 
 =over
 
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-30-runtime:1>
+
 =item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-30-runtime:8>
 
 =item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-30-runtime:8>
@@ -135,6 +137,8 @@ The Layer ARN list is here.
 
 =over
 
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-28-runtime:1>
+
 =item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-28-runtime:7>
 
 =item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-28-runtime:14>
@@ -174,6 +178,8 @@ The Layer ARN list is here.
 =item Perl 5.26
 
 =over
+
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-26-runtime:1>
 
 =item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-26-runtime:8>
 
@@ -319,6 +325,8 @@ The Layer ARN list is here.
 
 =over
 
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-30-paws:1>
+
 =item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-30-paws:5>
 
 =item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-30-paws:5>
@@ -359,6 +367,8 @@ The Layer ARN list is here.
 
 =over
 
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-28-paws:1>
+
 =item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-28-paws:4>
 
 =item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-28-paws:4>
@@ -398,6 +408,8 @@ The Layer ARN list is here.
 =item Perl 5.26
 
 =over
+
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-26-paws:1>
 
 =item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-26-paws:5>
 


### PR DESCRIPTION
ref. https://aws.amazon.com/jp/about-aws/whats-new/2020/04/announcing-aws-africa-cape-town-region/