### PR TITLE
prepare for releasing v0.4.2

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension aws-lambda
 
 {{$NEXT}}
+    - bump Paws v0.46 #138
     - bump YAML 1.31 #136
     - bump Net::SSLeay 1.94 #137
 

--- a/author/perlstrip.sh
+++ b/author/perlstrip.sh
@@ -2,8 +2,6 @@
 
 # perlstrip off loaded to AWS Lambda
 
-set -e
-
 echo "stripping $1..." 2>&1
-curl -sSf --upload-file "$1"  https://tsjax7b6xiykqv3zua6iankaia0ldqde.lambda-url.ap-northeast-1.on.aws/ -o "/tmp/perlstrip.$$"
-mv -f "/tmp/perlstrip.$$" "$1"
+curl -sSf --upload-file "$1"  https://tsjax7b6xiykqv3zua6iankaia0ldqde.lambda-url.ap-northeast-1.on.aws/ -o "/tmp/perlstrip.$$" || exit 0
+mv -f "/tmp/perlstrip.$$" "$1" || exit 0

--- a/lib/AWS/Lambda/AL2.pm
+++ b/lib/AWS/Lambda/AL2.pm
@@ -188,170 +188,170 @@ our $LAYERS = {
             'af-south-1' => {
                 runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'ap-east-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'ap-northeast-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'ap-northeast-2' => {
                 runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'ap-northeast-3' => {
                 runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'ap-south-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'ap-south-2' => {
                 runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2-arm64:3",
-                paws_version    => 3,
+                paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2-arm64:4",
+                paws_version    => 4,
             },
             'ap-southeast-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'ap-southeast-2' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'ap-southeast-3' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'ap-southeast-4' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2-arm64:3",
-                paws_version    => 3,
+                paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2-arm64:4",
+                paws_version    => 4,
             },
             'ca-central-1' => {
                 runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'eu-central-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'eu-central-2' => {
                 runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2-arm64:3",
-                paws_version    => 3,
+                paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2-arm64:4",
+                paws_version    => 4,
             },
             'eu-north-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'eu-south-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'eu-south-2' => {
                 runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2-arm64:3",
-                paws_version    => 3,
+                paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2-arm64:4",
+                paws_version    => 4,
             },
             'eu-west-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'eu-west-2' => {
                 runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'eu-west-3' => {
                 runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'il-central-1' => {
                 runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:3",
-                paws_version    => 3,
+                paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:4",
+                paws_version    => 4,
             },
             'me-central-1' => {
                 runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:3",
-                paws_version    => 3,
+                paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:4",
+                paws_version    => 4,
             },
             'me-south-1' => {
                 runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'sa-east-1' => {
                 runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'us-east-1' => {
                 runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'us-east-2' => {
                 runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'us-west-1' => {
                 runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
             'us-west-2' => {
                 runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
                 runtime_version => 8,
-                paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2-arm64:6",
-                paws_version    => 6,
+                paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2-arm64:7",
+                paws_version    => 7,
             },
         },
     },
@@ -360,346 +360,346 @@ our $LAYERS = {
             'af-south-1' => {
                 runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'ap-east-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'ap-northeast-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'ap-northeast-2' => {
                 runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'ap-northeast-3' => {
                 runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'ap-south-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'ap-south-2' => {
                 runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:6",
                 runtime_version => 6,
-                paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-paws-al2-x86_64:5",
-                paws_version    => 5,
+                paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'ap-southeast-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'ap-southeast-2' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'ap-southeast-3' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'ap-southeast-4' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-runtime-al2-x86_64:6",
                 runtime_version => 6,
-                paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-paws-al2-x86_64:5",
-                paws_version    => 5,
+                paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'ca-central-1' => {
                 runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'ca-west-1' => {
                 runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:3",
                 runtime_version => 3,
-                paws_arn        => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-36-paws-al2-x86_64:3",
-                paws_version    => 3,
+                paws_arn        => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-36-paws-al2-x86_64:4",
+                paws_version    => 4,
             },
             'eu-central-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'eu-central-2' => {
                 runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:6",
                 runtime_version => 6,
-                paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-paws-al2-x86_64:5",
-                paws_version    => 5,
+                paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'eu-north-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'eu-south-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'eu-south-2' => {
                 runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:6",
                 runtime_version => 6,
-                paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-paws-al2-x86_64:5",
-                paws_version    => 5,
+                paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'eu-west-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'eu-west-2' => {
                 runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'eu-west-3' => {
                 runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'il-central-1' => {
                 runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:6",
                 runtime_version => 6,
-                paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:5",
-                paws_version    => 5,
+                paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'me-central-1' => {
                 runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'me-south-1' => {
                 runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'sa-east-1' => {
                 runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'us-east-1' => {
                 runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'us-east-2' => {
                 runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'us-west-1' => {
                 runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
             'us-west-2' => {
                 runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
                 runtime_version => 10,
-                paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
-                paws_version    => 9,
+                paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-paws-al2-x86_64:10",
+                paws_version    => 10,
             },
         },
         'arm64' => {
             'af-south-1' => {
                 runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'ap-east-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'ap-northeast-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'ap-northeast-2' => {
                 runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'ap-northeast-3' => {
                 runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'ap-south-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'ap-south-2' => {
                 runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-runtime-al2-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-paws-al2-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-paws-al2-arm64:3",
+                paws_version    => 3,
             },
             'ap-southeast-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'ap-southeast-2' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'ap-southeast-3' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'ap-southeast-4' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-runtime-al2-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-paws-al2-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-paws-al2-arm64:3",
+                paws_version    => 3,
             },
             'ca-central-1' => {
                 runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'eu-central-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'eu-central-2' => {
                 runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-runtime-al2-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-paws-al2-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-paws-al2-arm64:3",
+                paws_version    => 3,
             },
             'eu-north-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'eu-south-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'eu-south-2' => {
                 runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-runtime-al2-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-paws-al2-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-paws-al2-arm64:3",
+                paws_version    => 3,
             },
             'eu-west-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'eu-west-2' => {
                 runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'eu-west-3' => {
                 runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'il-central-1' => {
                 runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:3",
+                paws_version    => 3,
             },
             'me-central-1' => {
                 runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:3",
+                paws_version    => 3,
             },
             'me-south-1' => {
                 runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'sa-east-1' => {
                 runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'us-east-1' => {
                 runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'us-east-2' => {
                 runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'us-west-1' => {
                 runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
             'us-west-2' => {
                 runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
-                paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-paws-al2-arm64:8",
-                paws_version    => 8,
+                paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-paws-al2-arm64:9",
+                paws_version    => 9,
             },
         },
     },
@@ -1867,61 +1867,61 @@ And Paws layers:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2-arm64:3>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2-arm64:4>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2-arm64:3>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2-arm64:4>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2-arm64:3>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2-arm64:4>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2-arm64:3>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2-arm64:4>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:3>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:4>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:3>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:4>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2-arm64:6>
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2-arm64:7>
 
 =back
 
@@ -1935,63 +1935,63 @@ And Paws layers:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-36-paws-al2-x86_64:3>
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-36-paws-al2-x86_64:4>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-paws-al2-x86_64:9>
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
 =back
 
@@ -1999,61 +1999,61 @@ And Paws layers:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-paws-al2-arm64:2>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-paws-al2-arm64:3>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-paws-al2-arm64:2>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-paws-al2-arm64:3>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-paws-al2-arm64:2>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-paws-al2-arm64:3>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-paws-al2-arm64:2>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-paws-al2-arm64:3>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:2>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:3>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:2>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:3>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-paws-al2-arm64:8>
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 
 =back
 

--- a/lib/AWS/Lambda/AL2.pm
+++ b/lib/AWS/Lambda/AL2.pm
@@ -10,346 +10,346 @@ our $LAYERS = {
     '5.38' => {
         'x86_64' => {
             'af-south-1' => {
-                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
-                paws_version    => 6,
+                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
+                paws_version    => 7,
             },
             'ap-east-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
-                paws_version    => 6,
+                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
+                paws_version    => 7,
             },
             'ap-northeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
-                paws_version    => 6,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
+                paws_version    => 7,
             },
             'ap-northeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
-                paws_version    => 6,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
+                paws_version    => 7,
             },
             'ap-northeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
-                paws_version    => 6,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
+                paws_version    => 7,
             },
             'ap-south-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
-                paws_version    => 6,
+                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
+                paws_version    => 7,
             },
             'ap-south-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:6",
-                runtime_version => 6,
-                paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
-                paws_version    => 5,
+                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
+                runtime_version => 7,
+                paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'ap-southeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
-                paws_version    => 6,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
+                paws_version    => 7,
             },
             'ap-southeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
-                paws_version    => 6,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
+                paws_version    => 7,
             },
             'ap-southeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
-                paws_version    => 6,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
+                paws_version    => 7,
             },
             'ap-southeast-4' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2-x86_64:6",
-                runtime_version => 6,
-                paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
-                paws_version    => 5,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
+                runtime_version => 7,
+                paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'ca-central-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
-                paws_version    => 5,
+                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'ca-west-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:2",
-                runtime_version => 2,
-                paws_arn        => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-paws-al2-x86_64:1",
-                paws_version    => 1,
+                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:3",
+                runtime_version => 3,
+                paws_arn        => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-paws-al2-x86_64:2",
+                paws_version    => 2,
             },
             'eu-central-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
-                paws_version    => 5,
+                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'eu-central-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:6",
-                runtime_version => 6,
-                paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2-x86_64:4",
-                paws_version    => 4,
+                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
+                runtime_version => 7,
+                paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
+                paws_version    => 5,
             },
             'eu-north-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
-                paws_version    => 5,
+                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'eu-south-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
-                paws_version    => 5,
+                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'eu-south-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:6",
-                runtime_version => 6,
-                paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2-x86_64:4",
-                paws_version    => 4,
+                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
+                runtime_version => 7,
+                paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
+                paws_version    => 5,
             },
             'eu-west-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
-                paws_version    => 5,
+                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'eu-west-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
-                paws_version    => 5,
+                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'eu-west-3' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
-                paws_version    => 5,
+                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'il-central-1' => {
-                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:6",
-                runtime_version => 6,
-                paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:4",
-                paws_version    => 4,
+                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
+                runtime_version => 7,
+                paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
+                paws_version    => 5,
             },
             'me-central-1' => {
-                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
-                paws_version    => 5,
+                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'me-south-1' => {
-                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
-                paws_version    => 5,
+                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'sa-east-1' => {
-                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
-                paws_version    => 5,
+                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'us-east-1' => {
-                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
-                paws_version    => 5,
+                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'us-east-2' => {
-                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
-                paws_version    => 5,
+                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'us-west-1' => {
-                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
-                paws_version    => 5,
+                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
             'us-west-2' => {
-                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:7",
-                runtime_version => 7,
-                paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2-x86_64:5",
-                paws_version    => 5,
+                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
+                runtime_version => 8,
+                paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
+                paws_version    => 6,
             },
         },
         'arm64' => {
             'af-south-1' => {
-                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'ap-east-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'ap-northeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'ap-northeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'ap-northeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'ap-south-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'ap-south-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2-arm64:3",
                 paws_version    => 3,
             },
             'ap-southeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'ap-southeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'ap-southeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'ap-southeast-4' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2-arm64:3",
                 paws_version    => 3,
             },
             'ca-central-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'eu-central-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'eu-central-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2-arm64:3",
                 paws_version    => 3,
             },
             'eu-north-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'eu-south-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'eu-south-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2-arm64:3",
                 paws_version    => 3,
             },
             'eu-west-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'eu-west-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'eu-west-3' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'il-central-1' => {
-                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:3",
                 paws_version    => 3,
             },
             'me-central-1' => {
-                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:3",
                 paws_version    => 3,
             },
             'me-south-1' => {
-                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'sa-east-1' => {
-                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'us-east-1' => {
-                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'us-east-2' => {
-                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'us-west-1' => {
-                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
             'us-west-2' => {
-                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:7",
-                runtime_version => 7,
+                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:8",
+                runtime_version => 8,
                 paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2-arm64:6",
                 paws_version    => 6,
             },
@@ -358,346 +358,346 @@ our $LAYERS = {
     '5.36' => {
         'x86_64' => {
             'af-south-1' => {
-                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'ap-east-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'ap-northeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'ap-northeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'ap-northeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'ap-south-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'ap-south-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-paws-al2-x86_64:5",
                 paws_version    => 5,
             },
             'ap-southeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'ap-southeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'ap-southeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'ap-southeast-4' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-runtime-al2-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-runtime-al2-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-paws-al2-x86_64:5",
                 paws_version    => 5,
             },
             'ca-central-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'ca-west-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:2",
-                runtime_version => 2,
+                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:3",
+                runtime_version => 3,
                 paws_arn        => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-36-paws-al2-x86_64:3",
                 paws_version    => 3,
             },
             'eu-central-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'eu-central-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-paws-al2-x86_64:5",
                 paws_version    => 5,
             },
             'eu-north-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'eu-south-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'eu-south-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-paws-al2-x86_64:5",
                 paws_version    => 5,
             },
             'eu-west-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'eu-west-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'eu-west-3' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'il-central-1' => {
-                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:5",
                 paws_version    => 5,
             },
             'me-central-1' => {
-                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'me-south-1' => {
-                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'sa-east-1' => {
-                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'us-east-1' => {
-                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'us-east-2' => {
-                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'us-west-1' => {
-                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
             'us-west-2' => {
-                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-paws-al2-x86_64:9",
                 paws_version    => 9,
             },
         },
         'arm64' => {
             'af-south-1' => {
-                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-east-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-northeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-northeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-northeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-south-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-south-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-runtime-al2-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-runtime-al2-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-paws-al2-arm64:2",
                 paws_version    => 2,
             },
             'ap-southeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-southeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-southeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-southeast-4' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-runtime-al2-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-runtime-al2-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-paws-al2-arm64:2",
                 paws_version    => 2,
             },
             'ca-central-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'eu-central-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'eu-central-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-runtime-al2-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-runtime-al2-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-paws-al2-arm64:2",
                 paws_version    => 2,
             },
             'eu-north-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'eu-south-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'eu-south-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-runtime-al2-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-runtime-al2-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-paws-al2-arm64:2",
                 paws_version    => 2,
             },
             'eu-west-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'eu-west-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'eu-west-3' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'il-central-1' => {
-                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:2",
                 paws_version    => 2,
             },
             'me-central-1' => {
-                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:2",
                 paws_version    => 2,
             },
             'me-south-1' => {
-                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'sa-east-1' => {
-                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'us-east-1' => {
-                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'us-east-2' => {
-                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'us-west-1' => {
-                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'us-west-2' => {
-                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-runtime-al2-arm64:10",
-                runtime_version => 10,
+                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
+                runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-paws-al2-arm64:8",
                 paws_version    => 8,
             },
@@ -1295,10 +1295,10 @@ You can get the layer ARN in your script by using C<get_layer_info>.
         "us-east-1", # Region
         "x86_64",    # Architecture ("x86_64" or "arm64", optional, the default is "x86_64")
     );
-    say $info->{runtime_arn};     # arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7
-    say $info->{runtime_version}; # 7
-    say $info->{paws_arn}         # arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5
-    say $info->{paws_version}     # 5,
+    say $info->{runtime_arn};     # arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8
+    say $info->{runtime_version}; # 8
+    say $info->{paws_arn}         # arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6
+    say $info->{paws_version}     # 6,
 
 Or, you can use following one-liner.
 
@@ -1317,63 +1317,63 @@ The list of all available layer ARN is here:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:6>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2-x86_64:6>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:2>
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:3>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:6>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:6>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:6>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:7>
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
 
 =back
 
@@ -1381,61 +1381,61 @@ The list of all available layer ARN is here:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:3>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:4>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2-arm64:3>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2-arm64:4>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2-arm64:3>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2-arm64:4>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:3>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:4>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:3>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:4>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:3>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:4>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:7>
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:8>
 
 =back
 
@@ -1449,63 +1449,63 @@ The list of all available layer ARN is here:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:5>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:6>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-runtime-al2-x86_64:5>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-runtime-al2-x86_64:6>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:2>
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:3>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:5>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:6>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:5>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:6>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:5>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:6>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
 =back
 
@@ -1513,61 +1513,61 @@ The list of all available layer ARN is here:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-runtime-al2-arm64:3>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-36-runtime-al2-arm64:4>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-runtime-al2-arm64:3>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-runtime-al2-arm64:4>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-runtime-al2-arm64:3>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-36-runtime-al2-arm64:4>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-runtime-al2-arm64:3>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-36-runtime-al2-arm64:4>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:3>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:4>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:3>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:4>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-runtime-al2-arm64:10>
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
 =back
 
@@ -1803,63 +1803,63 @@ And Paws layers:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2-x86_64:7>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2-x86_64:7>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2-x86_64:7>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2-x86_64:7>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-paws-al2-x86_64:1>
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-paws-al2-x86_64:2>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2-x86_64:4>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2-x86_64:4>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:4>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2-x86_64:5>
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2-x86_64:6>
 
 =back
 

--- a/lib/AWS/Lambda/AL2023.pm
+++ b/lib/AWS/Lambda/AL2023.pm
@@ -10,346 +10,346 @@ our $LAYERS = {
     '5.38' => {
         'x86_64' => {
             'af-south-1' => {
-                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'ap-east-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'ap-northeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'ap-northeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'ap-northeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'ap-south-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'ap-south-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'ap-southeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'ap-southeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'ap-southeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'ap-southeast-4' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'ca-central-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'ca-west-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:2",
-                runtime_version => 2,
+                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
+                runtime_version => 3,
                 paws_arn        => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:2",
                 paws_version    => 2,
             },
             'eu-central-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'eu-central-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'eu-north-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'eu-south-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'eu-south-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'eu-west-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'eu-west-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'eu-west-3' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'il-central-1' => {
-                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'me-central-1' => {
-                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'me-south-1' => {
-                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'sa-east-1' => {
-                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'us-east-1' => {
-                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'us-east-2' => {
-                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'us-west-1' => {
-                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'us-west-2' => {
-                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
         },
         'arm64' => {
             'af-south-1' => {
-                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'ap-east-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'ap-northeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'ap-northeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'ap-northeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'ap-south-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'ap-south-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'ap-southeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'ap-southeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'ap-southeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'ap-southeast-4' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'ca-central-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'eu-central-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'eu-central-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'eu-north-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'eu-south-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'eu-south-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'eu-west-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'eu-west-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'eu-west-3' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'il-central-1' => {
-                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'me-central-1' => {
-                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'me-south-1' => {
-                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'sa-east-1' => {
-                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'us-east-1' => {
-                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'us-east-2' => {
-                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'us-west-1' => {
-                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
             'us-west-2' => {
-                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:3",
-                runtime_version => 3,
+                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
+                runtime_version => 4,
                 paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
                 paws_version    => 2,
             },
@@ -395,8 +395,8 @@ You can get the layer ARN in your script by using C<get_layer_info>.
         "us-east-1", # Region
         "x86_64",    # Architecture ("x86_64" or "arm64", optional, the default is "x86_64")
     );
-    say $info->{runtime_arn};     # arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3
-    say $info->{runtime_version}; # 3
+    say $info->{runtime_arn};     # arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4
+    say $info->{runtime_version}; # 4
     say $info->{paws_arn}         # arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4
     say $info->{paws_version}     # 4,
 
@@ -417,63 +417,63 @@ The list of all available layer ARN is here:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:2>
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3>
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
 
 =back
 
@@ -481,61 +481,61 @@ The list of all available layer ARN is here:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:3>
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4>
 
 =back
 

--- a/lib/AWS/Lambda/AL2023.pm
+++ b/lib/AWS/Lambda/AL2023.pm
@@ -12,346 +12,346 @@ our $LAYERS = {
             'af-south-1' => {
                 runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'ap-east-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'ap-northeast-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'ap-northeast-2' => {
                 runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'ap-northeast-3' => {
                 runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'ap-south-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'ap-south-2' => {
                 runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'ap-southeast-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'ap-southeast-2' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'ap-southeast-3' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'ap-southeast-4' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'ca-central-1' => {
                 runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'ca-west-1' => {
                 runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:3",
                 runtime_version => 3,
-                paws_arn        => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:3",
+                paws_version    => 3,
             },
             'eu-central-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'eu-central-2' => {
                 runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'eu-north-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'eu-south-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'eu-south-2' => {
                 runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'eu-west-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'eu-west-2' => {
                 runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'eu-west-3' => {
                 runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'il-central-1' => {
                 runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'me-central-1' => {
                 runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'me-south-1' => {
                 runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'sa-east-1' => {
                 runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'us-east-1' => {
                 runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'us-east-2' => {
                 runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'us-west-1' => {
                 runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
             'us-west-2' => {
                 runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
-                paws_version    => 4,
+                paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:5",
+                paws_version    => 5,
             },
         },
         'arm64' => {
             'af-south-1' => {
                 runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'ap-east-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'ap-northeast-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'ap-northeast-2' => {
                 runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'ap-northeast-3' => {
                 runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'ap-south-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'ap-south-2' => {
                 runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'ap-southeast-1' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'ap-southeast-2' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'ap-southeast-3' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'ap-southeast-4' => {
                 runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'ca-central-1' => {
                 runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'eu-central-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'eu-central-2' => {
                 runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'eu-north-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'eu-south-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'eu-south-2' => {
                 runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'eu-west-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'eu-west-2' => {
                 runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'eu-west-3' => {
                 runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'il-central-1' => {
                 runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'me-central-1' => {
                 runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'me-south-1' => {
                 runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'sa-east-1' => {
                 runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'us-east-1' => {
                 runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'us-east-2' => {
                 runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'us-west-1' => {
                 runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
             'us-west-2' => {
                 runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:4",
                 runtime_version => 4,
-                paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2",
-                paws_version    => 2,
+                paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2023-arm64:3",
+                paws_version    => 3,
             },
         },
     },
@@ -397,8 +397,8 @@ You can get the layer ARN in your script by using C<get_layer_info>.
     );
     say $info->{runtime_arn};     # arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4
     say $info->{runtime_version}; # 4
-    say $info->{paws_arn}         # arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4
-    say $info->{paws_version}     # 4,
+    say $info->{paws_arn}         # arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5
+    say $info->{paws_version}     # 5,
 
 Or, you can use following one-liner.
 
@@ -555,63 +555,63 @@ And Paws layers:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:2>
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:3>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:5>
 
 =back
 
@@ -619,61 +619,61 @@ And Paws layers:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2023-arm64:2>
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2023-arm64:3>
 
 =back
 


### PR DESCRIPTION
- [x] build-perl-runtime-al2
- [x] build-perl-runtime-al2023
- [x] build-paws-layer-al2
- [x] build-paws-layer-al2023
- [x] publish-perl-runtimes
- [x] publish-perl-runtime-archives
- [x] update-aws-lambda-al2
- [x] update-aws-lambda-al2023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Paws library to version 0.46.
  - Modified `perlstrip.sh` script to ensure safe file movement after successful upload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->