### PR TITLE
prepare for releasing v0.5.1

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl extension aws-lambda
 
 {{$NEXT}}
+    - ap-southeast-5 is available
+    - AWS Lambda Functions powered by AWS Graviton2 now available on ca-west-1
     - bump JSON::MaybeXS 1.004008 #152, #153
     - bump Mozilla::CA 20240730 #150
     - bump IO::Socket::SSL 2.088 #147, 148, #149

--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for Perl extension aws-lambda
 
 {{$NEXT}}
+    - bump JSON::MaybeXS 1.004008 #152, #153
+    - bump Mozilla::CA 20240730 #150
+    - bump IO::Socket::SSL 2.088 #147, 148, #149
 
 0.5.0 2024-06-11T05:13:06Z
     - Perl 5.40.0 is released

--- a/author/regions-arm64.txt
+++ b/author/regions-arm64.txt
@@ -9,7 +9,9 @@ ap-southeast-1
 ap-southeast-2
 ap-southeast-3
 ap-southeast-4
+ap-southeast-5
 ca-central-1
+ca-west-1
 eu-central-1
 eu-central-2
 eu-north-1

--- a/author/regions-x86_64.txt
+++ b/author/regions-x86_64.txt
@@ -9,6 +9,7 @@ ap-southeast-1
 ap-southeast-2
 ap-southeast-3
 ap-southeast-4
+ap-southeast-5
 ca-central-1
 ca-west-1
 eu-central-1

--- a/lib/AWS/Lambda/AL2.pm
+++ b/lib/AWS/Lambda/AL2.pm
@@ -10,346 +10,364 @@ our $LAYERS = {
     '5.40' => {
         'x86_64' => {
             'af-south-1' => {
-                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'ap-east-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'ap-northeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'ap-northeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'ap-northeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'ap-south-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'ap-south-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'ap-southeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'ap-southeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'ap-southeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'ap-southeast-4' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
-            'ca-central-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
+            'ap-southeast-5' => {
+                runtime_arn     => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
                 runtime_version => 1,
+                paws_arn        => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
+                paws_version    => 1,
+            },
+            'ca-central-1' => {
+                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'ca-west-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'eu-central-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'eu-central-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'eu-north-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'eu-south-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'eu-south-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'eu-west-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'eu-west-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'eu-west-3' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'il-central-1' => {
-                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'me-central-1' => {
-                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'me-south-1' => {
-                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'sa-east-1' => {
-                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'us-east-1' => {
-                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'us-east-2' => {
-                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'us-west-1' => {
-                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
             'us-west-2' => {
-                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-paws-al2-x86_64:1",
                 paws_version    => 1,
             },
         },
         'arm64' => {
             'af-south-1' => {
-                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'ap-east-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'ap-northeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'ap-northeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'ap-northeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'ap-south-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'ap-south-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'ap-southeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'ap-southeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'ap-southeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'ap-southeast-4' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
-            'ca-central-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
+            'ap-southeast-5' => {
+                runtime_arn     => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
                 runtime_version => 1,
+                paws_arn        => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-40-paws-al2-arm64:1",
+                paws_version    => 1,
+            },
+            'ca-central-1' => {
+                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
-            'eu-central-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
+            'ca-west-1' => {
+                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
                 runtime_version => 1,
+                paws_arn        => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-paws-al2-arm64:1",
+                paws_version    => 1,
+            },
+            'eu-central-1' => {
+                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'eu-central-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'eu-north-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'eu-south-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'eu-south-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'eu-west-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'eu-west-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'eu-west-3' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'il-central-1' => {
-                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'me-central-1' => {
-                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'me-south-1' => {
-                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'sa-east-1' => {
-                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'us-east-1' => {
-                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'us-east-2' => {
-                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'us-west-1' => {
-                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
             'us-west-2' => {
-                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-runtime-al2-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-runtime-al2-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-paws-al2-arm64:1",
                 paws_version    => 1,
             },
@@ -358,346 +376,364 @@ our $LAYERS = {
     '5.38' => {
         'x86_64' => {
             'af-south-1' => {
-                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:8",
                 paws_version    => 8,
             },
             'ap-east-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2-x86_64:8",
                 paws_version    => 8,
             },
             'ap-northeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2-x86_64:8",
                 paws_version    => 8,
             },
             'ap-northeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2-x86_64:8",
                 paws_version    => 8,
             },
             'ap-northeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2-x86_64:8",
                 paws_version    => 8,
             },
             'ap-south-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:8",
                 paws_version    => 8,
             },
             'ap-south-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
-                runtime_version => 8,
+                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
+                runtime_version => 9,
                 paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
                 paws_version    => 7,
             },
             'ap-southeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2-x86_64:8",
                 paws_version    => 8,
             },
             'ap-southeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2-x86_64:8",
                 paws_version    => 8,
             },
             'ap-southeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2-x86_64:8",
                 paws_version    => 8,
             },
             'ap-southeast-4' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
-                runtime_version => 8,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
+                runtime_version => 9,
                 paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
                 paws_version    => 7,
             },
+            'ap-southeast-5' => {
+                runtime_arn     => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-38-runtime-al2-x86_64:1",
+                runtime_version => 1,
+                paws_arn        => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-38-paws-al2-x86_64:1",
+                paws_version    => 1,
+            },
             'ca-central-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
                 paws_version    => 7,
             },
             'ca-west-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:4",
-                runtime_version => 4,
+                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:5",
+                runtime_version => 5,
                 paws_arn        => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-paws-al2-x86_64:3",
                 paws_version    => 3,
             },
             'eu-central-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
                 paws_version    => 7,
             },
             'eu-central-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
-                runtime_version => 8,
+                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
+                runtime_version => 9,
                 paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
                 paws_version    => 6,
             },
             'eu-north-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
                 paws_version    => 7,
             },
             'eu-south-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
                 paws_version    => 7,
             },
             'eu-south-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
-                runtime_version => 8,
+                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
+                runtime_version => 9,
                 paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
                 paws_version    => 6,
             },
             'eu-west-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
                 paws_version    => 7,
             },
             'eu-west-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
                 paws_version    => 7,
             },
             'eu-west-3' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
                 paws_version    => 7,
             },
             'il-central-1' => {
-                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8",
-                runtime_version => 8,
+                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
+                runtime_version => 9,
                 paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:6",
                 paws_version    => 6,
             },
             'me-central-1' => {
-                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
                 paws_version    => 7,
             },
             'me-south-1' => {
-                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
                 paws_version    => 7,
             },
             'sa-east-1' => {
-                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
                 paws_version    => 7,
             },
             'us-east-1' => {
-                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
                 paws_version    => 7,
             },
             'us-east-2' => {
-                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
                 paws_version    => 7,
             },
             'us-west-1' => {
-                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
                 paws_version    => 7,
             },
             'us-west-2' => {
-                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2-x86_64:7",
                 paws_version    => 7,
             },
         },
         'arm64' => {
             'af-south-1' => {
-                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-east-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-northeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-northeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-northeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-south-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-south-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2-arm64:5",
                 paws_version    => 5,
             },
             'ap-southeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-southeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-southeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'ap-southeast-4' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2-arm64:5",
                 paws_version    => 5,
             },
+            'ap-southeast-5' => {
+                runtime_arn     => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-38-runtime-al2-arm64:1",
+                runtime_version => 1,
+                paws_arn        => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-38-paws-al2-arm64:1",
+                paws_version    => 1,
+            },
             'ca-central-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
+            'ca-west-1' => {
+                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:1",
+                runtime_version => 1,
+                paws_arn        => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-paws-al2-arm64:1",
+                paws_version    => 1,
+            },
             'eu-central-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'eu-central-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2-arm64:5",
                 paws_version    => 5,
             },
             'eu-north-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'eu-south-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'eu-south-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2-arm64:5",
                 paws_version    => 5,
             },
             'eu-west-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'eu-west-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'eu-west-3' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'il-central-1' => {
-                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:5",
                 paws_version    => 5,
             },
             'me-central-1' => {
-                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:5",
                 paws_version    => 5,
             },
             'me-south-1' => {
-                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'sa-east-1' => {
-                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'us-east-1' => {
-                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'us-east-2' => {
-                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'us-west-1' => {
-                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
             'us-west-2' => {
-                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:9",
-                runtime_version => 9,
+                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:10",
+                runtime_version => 10,
                 paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2-arm64:8",
                 paws_version    => 8,
             },
@@ -770,6 +806,12 @@ our $LAYERS = {
                 runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-paws-al2-x86_64:6",
                 paws_version    => 6,
+            },
+            'ap-southeast-5' => {
+                runtime_arn     => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-36-runtime-al2-x86_64:1",
+                runtime_version => 1,
+                paws_arn        => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-36-paws-al2-x86_64:1",
+                paws_version    => 1,
             },
             'ca-central-1' => {
                 runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10",
@@ -947,11 +989,23 @@ our $LAYERS = {
                 paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-paws-al2-arm64:3",
                 paws_version    => 3,
             },
+            'ap-southeast-5' => {
+                runtime_arn     => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-36-runtime-al2-arm64:1",
+                runtime_version => 1,
+                paws_arn        => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-36-paws-al2-arm64:1",
+                paws_version    => 1,
+            },
             'ca-central-1' => {
                 runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
                 runtime_version => 11,
                 paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:9",
                 paws_version    => 9,
+            },
+            'ca-west-1' => {
+                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-36-runtime-al2-arm64:1",
+                runtime_version => 1,
+                paws_arn        => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-36-paws-al2-arm64:1",
+                paws_version    => 1,
             },
             'eu-central-1' => {
                 runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11",
@@ -1643,8 +1697,8 @@ You can get the layer ARN in your script by using C<get_layer_info>.
         "us-east-1", # Region
         "x86_64",    # Architecture ("x86_64" or "arm64", optional, the default is "x86_64")
     );
-    say $info->{runtime_arn};     # arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1
-    say $info->{runtime_version}; # 1
+    say $info->{runtime_arn};     # arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2
+    say $info->{runtime_version}; # 2
     say $info->{paws_arn}         # arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1
     say $info->{paws_version}     # 1,
 
@@ -1665,63 +1719,65 @@ The list of all available layer ARN is here:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
 
-=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:1>
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
+
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-runtime-al2-x86_64:2>
 
 =back
 
@@ -1729,61 +1785,65 @@ The list of all available layer ARN is here:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-runtime-al2-arm64:1>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
+
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
+
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-runtime-al2-arm64:2>
 
 =back
 
@@ -1797,63 +1857,65 @@ The list of all available layer ARN is here:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-38-runtime-al2-x86_64:1>
 
-=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:4>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:5>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:8>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:9>
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
+
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2-x86_64:10>
 
 =back
 
@@ -1861,61 +1923,65 @@ The list of all available layer ARN is here:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:5>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:6>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2-arm64:5>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2-arm64:6>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-38-runtime-al2-arm64:1>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2-arm64:5>
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:1>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2-arm64:6>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:5>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2-arm64:6>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:5>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:5>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:6>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2-arm64:6>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:9>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
+
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
+
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2-arm64:10>
 
 =back
 
@@ -1950,6 +2016,8 @@ The list of all available layer ARN is here:
 =item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
 =item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-runtime-al2-x86_64:6>
+
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-36-runtime-al2-x86_64:1>
 
 =item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-runtime-al2-x86_64:10>
 
@@ -2015,7 +2083,11 @@ The list of all available layer ARN is here:
 
 =item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-runtime-al2-arm64:4>
 
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-36-runtime-al2-arm64:1>
+
 =item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
+
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-36-runtime-al2-arm64:1>
 
 =item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-runtime-al2-arm64:11>
 
@@ -2305,6 +2377,8 @@ And Paws layers:
 
 =item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-paws-al2-x86_64:1>
 
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-40-paws-al2-x86_64:1>
+
 =item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1>
 
 =item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-paws-al2-x86_64:1>
@@ -2369,7 +2443,11 @@ And Paws layers:
 
 =item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-paws-al2-arm64:1>
 
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-40-paws-al2-arm64:1>
+
 =item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-paws-al2-arm64:1>
+
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-paws-al2-arm64:1>
 
 =item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-paws-al2-arm64:1>
 
@@ -2437,6 +2515,8 @@ And Paws layers:
 
 =item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2-x86_64:7>
 
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-38-paws-al2-x86_64:1>
+
 =item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2-x86_64:7>
 
 =item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-paws-al2-x86_64:3>
@@ -2501,7 +2581,11 @@ And Paws layers:
 
 =item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2-arm64:5>
 
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-38-paws-al2-arm64:1>
+
 =item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:8>
+
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-paws-al2-arm64:1>
 
 =item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2-arm64:8>
 
@@ -2569,6 +2653,8 @@ And Paws layers:
 
 =item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-paws-al2-x86_64:6>
 
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-36-paws-al2-x86_64:1>
+
 =item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-paws-al2-x86_64:10>
 
 =item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-36-paws-al2-x86_64:4>
@@ -2633,7 +2719,11 @@ And Paws layers:
 
 =item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-36-paws-al2-arm64:3>
 
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-36-paws-al2-arm64:1>
+
 =item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:9>
+
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-36-paws-al2-arm64:1>
 
 =item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-36-paws-al2-arm64:9>
 

--- a/lib/AWS/Lambda/AL2023.pm
+++ b/lib/AWS/Lambda/AL2023.pm
@@ -10,346 +10,364 @@ our $LAYERS = {
     '5.40' => {
         'x86_64' => {
             'af-south-1' => {
-                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'ap-east-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'ap-northeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'ap-northeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'ap-northeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'ap-south-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'ap-south-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'ap-southeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'ap-southeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'ap-southeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'ap-southeast-4' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
-            'ca-central-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
+            'ap-southeast-5' => {
+                runtime_arn     => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
                 runtime_version => 1,
+                paws_arn        => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
+                paws_version    => 1,
+            },
+            'ca-central-1' => {
+                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'ca-west-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'eu-central-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'eu-central-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'eu-north-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'eu-south-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'eu-south-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'eu-west-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'eu-west-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'eu-west-3' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'il-central-1' => {
-                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'me-central-1' => {
-                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'me-south-1' => {
-                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'sa-east-1' => {
-                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'us-east-1' => {
-                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'us-east-2' => {
-                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'us-west-1' => {
-                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
             'us-west-2' => {
-                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-paws-al2023-x86_64:1",
                 paws_version    => 1,
             },
         },
         'arm64' => {
             'af-south-1' => {
-                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'ap-east-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'ap-northeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'ap-northeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'ap-northeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'ap-south-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'ap-south-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'ap-southeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'ap-southeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'ap-southeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'ap-southeast-4' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
-            'ca-central-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
+            'ap-southeast-5' => {
+                runtime_arn     => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
                 runtime_version => 1,
+                paws_arn        => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
+                paws_version    => 1,
+            },
+            'ca-central-1' => {
+                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
-            'eu-central-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
+            'ca-west-1' => {
+                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
                 runtime_version => 1,
+                paws_arn        => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
+                paws_version    => 1,
+            },
+            'eu-central-1' => {
+                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'eu-central-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'eu-north-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'eu-south-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'eu-south-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'eu-west-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'eu-west-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'eu-west-3' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'il-central-1' => {
-                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'me-central-1' => {
-                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'me-south-1' => {
-                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'sa-east-1' => {
-                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'us-east-1' => {
-                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'us-east-2' => {
-                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'us-west-1' => {
-                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
             'us-west-2' => {
-                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:1",
-                runtime_version => 1,
+                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:2",
+                runtime_version => 2,
                 paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-paws-al2023-arm64:1",
                 paws_version    => 1,
             },
@@ -358,346 +376,364 @@ our $LAYERS = {
     '5.38' => {
         'x86_64' => {
             'af-south-1' => {
-                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'ap-east-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'ap-northeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'ap-northeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'ap-northeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'ap-south-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'ap-south-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'ap-southeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'ap-southeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'ap-southeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'ap-southeast-4' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
+            'ap-southeast-5' => {
+                runtime_arn     => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-38-runtime-al2023-x86_64:1",
+                runtime_version => 1,
+                paws_arn        => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-38-paws-al2023-x86_64:1",
+                paws_version    => 1,
+            },
             'ca-central-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'ca-west-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4",
-                runtime_version => 4,
+                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
+                runtime_version => 5,
                 paws_arn        => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4",
                 paws_version    => 4,
             },
             'eu-central-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'eu-central-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'eu-north-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'eu-south-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'eu-south-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'eu-west-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'eu-west-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'eu-west-3' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'il-central-1' => {
-                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'me-central-1' => {
-                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'me-south-1' => {
-                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'sa-east-1' => {
-                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'us-east-1' => {
-                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'us-east-2' => {
-                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'us-west-1' => {
-                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
             'us-west-2' => {
-                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2023-x86_64:6",
                 paws_version    => 6,
             },
         },
         'arm64' => {
             'af-south-1' => {
-                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'ap-east-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'ap-northeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'ap-northeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'ap-northeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'ap-south-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'ap-south-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'ap-southeast-1' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'ap-southeast-2' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'ap-southeast-3' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'ap-southeast-4' => {
-                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
+            'ap-southeast-5' => {
+                runtime_arn     => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-38-runtime-al2023-arm64:1",
+                runtime_version => 1,
+                paws_arn        => "arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-38-paws-al2023-arm64:1",
+                paws_version    => 1,
+            },
             'ca-central-1' => {
-                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
+            'ca-west-1' => {
+                runtime_arn     => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:1",
+                runtime_version => 1,
+                paws_arn        => "arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-paws-al2023-arm64:1",
+                paws_version    => 1,
+            },
             'eu-central-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'eu-central-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'eu-north-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'eu-south-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'eu-south-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'eu-west-1' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'eu-west-2' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'eu-west-3' => {
-                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'il-central-1' => {
-                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'me-central-1' => {
-                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'me-south-1' => {
-                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'sa-east-1' => {
-                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'us-east-1' => {
-                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'us-east-2' => {
-                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'us-west-1' => {
-                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
             'us-west-2' => {
-                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:5",
-                runtime_version => 5,
+                runtime_arn     => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:6",
+                runtime_version => 6,
                 paws_arn        => "arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-paws-al2023-arm64:4",
                 paws_version    => 4,
             },
@@ -743,8 +779,8 @@ You can get the layer ARN in your script by using C<get_layer_info>.
         "us-east-1", # Region
         "x86_64",    # Architecture ("x86_64" or "arm64", optional, the default is "x86_64")
     );
-    say $info->{runtime_arn};     # arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1
-    say $info->{runtime_version}; # 1
+    say $info->{runtime_arn};     # arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2
+    say $info->{runtime_version}; # 2
     say $info->{paws_arn}         # arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1
     say $info->{paws_version}     # 1,
 
@@ -765,63 +801,65 @@ The list of all available layer ARN is here:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
 
-=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:1>
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
+
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-runtime-al2023-x86_64:2>
 
 =back
 
@@ -829,61 +867,65 @@ The list of all available layer ARN is here:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:1>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
+
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
+
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-40-runtime-al2023-arm64:2>
 
 =back
 
@@ -897,63 +939,65 @@ The list of all available layer ARN is here:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-38-runtime-al2023-x86_64:1>
 
-=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:4>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:5>
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
+
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-x86_64:6>
 
 =back
 
@@ -961,61 +1005,65 @@ The list of all available layer ARN is here:
 
 =over
 
-=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:af-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:ap-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:ap-northeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:ap-northeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:ap-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:ap-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:ap-southeast-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:ap-southeast-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-38-runtime-al2023-arm64:1>
 
-=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:1>
 
-=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:eu-central-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:eu-north-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:eu-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:eu-south-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:eu-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:eu-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:eu-west-3:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:il-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:me-central-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:me-south-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:sa-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:us-east-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
-=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:5>
+=item C<arn:aws:lambda:us-east-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
+
+=item C<arn:aws:lambda:us-west-1:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
+
+=item C<arn:aws:lambda:us-west-2:445285296882:layer:perl-5-38-runtime-al2023-arm64:6>
 
 =back
 
@@ -1056,6 +1104,8 @@ And Paws layers:
 =item C<arn:aws:lambda:ap-southeast-3:445285296882:layer:perl-5-40-paws-al2023-x86_64:1>
 
 =item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-paws-al2023-x86_64:1>
+
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-40-paws-al2023-x86_64:1>
 
 =item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-paws-al2023-x86_64:1>
 
@@ -1121,7 +1171,11 @@ And Paws layers:
 
 =item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-40-paws-al2023-arm64:1>
 
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-40-paws-al2023-arm64:1>
+
 =item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1>
+
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1>
 
 =item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-40-paws-al2023-arm64:1>
 
@@ -1189,6 +1243,8 @@ And Paws layers:
 
 =item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2023-x86_64:6>
 
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-38-paws-al2023-x86_64:1>
+
 =item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:6>
 
 =item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-paws-al2023-x86_64:4>
@@ -1253,7 +1309,11 @@ And Paws layers:
 
 =item C<arn:aws:lambda:ap-southeast-4:445285296882:layer:perl-5-38-paws-al2023-arm64:4>
 
+=item C<arn:aws:lambda:ap-southeast-5:445285296882:layer:perl-5-38-paws-al2023-arm64:1>
+
 =item C<arn:aws:lambda:ca-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4>
+
+=item C<arn:aws:lambda:ca-west-1:445285296882:layer:perl-5-38-paws-al2023-arm64:1>
 
 =item C<arn:aws:lambda:eu-central-1:445285296882:layer:perl-5-38-paws-al2023-arm64:4>
 


### PR DESCRIPTION
- [x] build-perl-runtime-al2
- [x] build-perl-runtime-al2023
- [x] build-paws-layer-al2
- [x] build-paws-layer-al2023
- [x] publish-perl-runtimes
- [x] publish-perl-runtime-archives
- [x] update-aws-lambda-al2
- [x] update-aws-lambda-al2023


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated dependencies for improved compatibility and security with the latest versions of key modules.
	- Expanded geographical coverage by adding new AWS regions (`ap-southeast-5` and `ca-west-1`) for deployment options.
	- Enhanced availability of Perl runtime layers across various AWS regions and architectures.
	- Updated documentation to reflect new ARNs and versions for better user guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->