### PR TITLE
install OpenSSL from the source

### DIFF
--- a/author/build-perl-al2.sh
+++ b/author/build-perl-al2.sh
@@ -6,6 +6,8 @@ set -uex
 
 PERL_VERSION=$1
 
+OPENSSL_VERSION=3.5.0
+
 NET_SSLEAY_VERSION=1.94
 CARTON_VERSION=v1.0.35
 AWS_XRAY_VERSION=0.12
@@ -20,6 +22,7 @@ IO_SOCKET_SSL_VERSION=2.089
 MOZILLA_CA_VERSION=20250202
 LOCAL_LIB_VERSION=2.000029
 
+# install Perl
 JOBS=$(nproc)
 curl -sL https://raw.githubusercontent.com/tokuhirom/Perl-Build/master/perl-build > /tmp/perl-build
 perl /tmp/perl-build "$PERL_VERSION" /opt --jobs="$JOBS" --noman -Dvendorprefix=/opt
@@ -27,12 +30,16 @@ perl /tmp/perl-build "$PERL_VERSION" /opt --jobs="$JOBS" --noman -Dvendorprefix=
 # workaround for "xlocale.h: No such file or directory"
 ln -s /usr/include/locale.h /usr/include/xlocale.h
 
-# build-provided.al2 lacks some development packages
-yum install -y openssl openssl-devel
-
-# some libraries are missing in the image for running.
-cp -R /lib64/libcrypt[.-]* /opt/lib/
-cp -R /usr/lib64/libcurl.* /opt/lib/
+# install OpenSSL
+(
+    cd /tmp
+    curl --retry 3 -sSL "https://github.com/openssl/openssl/archive/refs/tags/openssl-$OPENSSL_VERSION.tar.gz" -o openssl.tar.gz
+    tar zxvf /tmp/openssl.tar.gz
+    cd "openssl-openssl-$OPENSSL_VERSION"
+    /opt/bin/perl Configure --prefix=/opt --openssldir=/opt "-Wl,-rpath,\$(LIBRPATH)"
+    make -j "$JOBS" build_sw
+    make install_sw
+)
 
 # AWS::Lambda is installed as vendor modules.
 # site_perl is reserved for other AWS Lambda layers.
@@ -40,6 +47,7 @@ cp -R /usr/lib64/libcurl.* /opt/lib/
 export PERL_MM_OPT="INSTALLDIRS=vendor CCFLAGS=-I/opt/include LIBS=-L/opt/lib INSTALLMAN1DIR=none INSTALLMAN3DIR=none"
 export PERL_MB_OPT="--installdirs=vendor --ccflags=-I/opt/include --lddlflags=-L/opt/lib --config installman1dir= --config installsiteman1dir= --config installman3dir= --config installsiteman3dir="
 export PERL_MM_USE_DEFAULT=1
+export OPENSSL_PREFIX=/opt
 
 # install pre-installed modules
 curl -fsSL --compressed http://cpanmin.us | perl -i -pe 's(^#!.*perl$)(#!/opt/bin/perl)' > /tmp/cpanm
@@ -47,10 +55,8 @@ install /tmp/cpanm /opt/bin/cpanm
 curl -fsSL --compressed https://raw.githubusercontent.com/skaji/cpm/main/cpm | perl -i -pe 's(^#!.*perl$)(#!/opt/bin/perl)' > /tmp/cpm
 install /tmp/cpm /opt/bin/cpm
 
-# Net::SSLeay needs special CCFLAGS and LIBS to link
-PERL_MM_OPT="INSTALLDIRS=vendor INSTALLMAN1DIR=none INSTALLMAN3DIR=none" /opt/bin/cpanm --notest "Net::SSLeay@$NET_SSLEAY_VERSION"
-
 /opt/bin/cpanm --notest \
+    "Net::SSLeay@$NET_SSLEAY_VERSION" \
     "Carton@$CARTON_VERSION" \
     "AWS::XRay@$AWS_XRAY_VERSION" \
     "JSON@$JSON_VERSION" \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build scripts to manually download and install a specific version of OpenSSL from source, rather than using system packages.
	- Set an environment variable to reflect the new OpenSSL installation location.
	- Streamlined Perl module installation by integrating Net::SSLeay into the main installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->