### PR TITLE
speed up installing Pod::Strip

### DIFF
--- a/author/build-perl-al2.sh
+++ b/author/build-perl-al2.sh
@@ -72,5 +72,5 @@ perl -i -pe 's(^#!perl$)(#!/opt/bin/perl)' /opt/bootstrap
 # remove POD(Plain Old Documentation)
 yum install -y perl-ExtUtils-MakeMaker
 cd author/pod-stripper
-perl /opt/bin/cpanm --installdeps .
+perl /opt/bin/cpanm --installdeps --notest .
 perl ./scripts/pod_stripper.pl /opt/lib/perl5

--- a/author/build-perl-al2023.sh
+++ b/author/build-perl-al2023.sh
@@ -73,5 +73,5 @@ perl -i -pe 's(^#!perl$)(#!/opt/bin/perl)' /opt/bootstrap
 # remove POD(Plain Old Documentation)
 dnf install -y perl-ExtUtils-MakeMaker
 cd author/pod-stripper
-perl /opt/bin/cpanm --installdeps .
+perl /opt/bin/cpanm --installdeps --notest .
 perl ./scripts/pod_stripper.pl /opt/lib/perl5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the dependency installation process for the pod-stripper tool to skip running tests during installation, resulting in a faster setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->