### PR TITLE
ap-southeast-6 is available

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension aws-lambda
 
 {{$NEXT}}
+    - ap-southeast-6 is available #199
     - bump JSON::XS 4.04 and Cpanel::JSON::XS 4.04 #197
     - bump IO::Socket::SSL 2.095 #184, #187, #193
 

--- a/author/regions-arm64.txt
+++ b/author/regions-arm64.txt
@@ -11,6 +11,7 @@ ap-southeast-2
 ap-southeast-3
 ap-southeast-4
 ap-southeast-5
+ap-southeast-6
 ap-southeast-7
 ca-central-1
 ca-west-1

--- a/author/regions-x86_64.txt
+++ b/author/regions-x86_64.txt
@@ -11,6 +11,7 @@ ap-southeast-2
 ap-southeast-3
 ap-southeast-4
 ap-southeast-5
+ap-southeast-6
 ap-southeast-7
 ca-central-1
 ca-west-1


### PR DESCRIPTION
- https://aws.amazon.com/jp/blogs/aws/now-open-aws-asia-pacific-new-zealand-region/
- https://dev.classmethod.jp/articles/new-region-launch-ap-southeast-6/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the ap-southeast-6 region, enabling deployments and resource selection in this location for both ARM64 and x86_64 architectures. No changes required for existing configurations.

* **Documentation**
  * Updated the upcoming release notes to include the availability of ap-southeast-6, clarifying regional support for both architectures and ensuring users can reference the new region in configuration and planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->