### PR TITLE
Update Perl version and runtime for perl-stripper to 5.42 and al2023

### DIFF
--- a/author/perl-stripper/perl-stripper/Makefile
+++ b/author/perl-stripper/perl-stripper/Makefile
@@ -5,10 +5,10 @@ build-PerlStripper: $(ARTIFACTS_DIR)/cpanfile.snapshot
 $(ARTIFACTS_DIR)/cpanfile.snapshot: cpanfile.snapshot cpanfile
 	cp cpanfile.snapshot $(ARTIFACTS_DIR)
 	cp cpanfile $(ARTIFACTS_DIR)
-	docker run --rm -v $(ARTIFACTS_DIR):/var/task shogo82148/p5-aws-lambda:build-5.42.al2023 \
+	docker run --rm -v $(ARTIFACTS_DIR):/var/task --platform=linux/arm64 shogo82148/p5-aws-lambda:build-5.42.al2023 \
 		carton install --deployment
 
 .PHONY: update
 update:
-	docker run --rm -v $(PWD):/var/task shogo82148/p5-aws-lambda:build-5.42.al2023 \
+	docker run --rm -v $(PWD):/var/task --platform=linux/arm64 shogo82148/p5-aws-lambda:build-5.42.al2023 \
 		carton install

--- a/author/perl-stripper/perl-stripper/Makefile
+++ b/author/perl-stripper/perl-stripper/Makefile
@@ -5,10 +5,10 @@ build-PerlStripper: $(ARTIFACTS_DIR)/cpanfile.snapshot
 $(ARTIFACTS_DIR)/cpanfile.snapshot: cpanfile.snapshot cpanfile
 	cp cpanfile.snapshot $(ARTIFACTS_DIR)
 	cp cpanfile $(ARTIFACTS_DIR)
-	docker run --rm -v $(ARTIFACTS_DIR):/var/task shogo82148/p5-aws-lambda:build-5.38.al2 \
+	docker run --rm -v $(ARTIFACTS_DIR):/var/task shogo82148/p5-aws-lambda:build-5.42.al2023 \
 		carton install --deployment
 
 .PHONY: update
 update:
-	docker run --rm -v $(PWD):/var/task shogo82148/p5-aws-lambda:build-5.38.al2 \
+	docker run --rm -v $(PWD):/var/task shogo82148/p5-aws-lambda:build-5.42.al2023 \
 		carton install

--- a/author/perl-stripper/perl-stripper/cpanfile
+++ b/author/perl-stripper/perl-stripper/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl', '5.036000';
+requires 'perl', '5.042000';
 requires 'Perl::Strip', '1.1';
 
 requires 'Params::Util'; # it's not direct dependency. Perl::Strip forgets it?

--- a/author/perl-stripper/perl-stripper/cpanfile.snapshot
+++ b/author/perl-stripper/perl-stripper/cpanfile.snapshot
@@ -160,3 +160,10 @@ DISTRIBUTIONS
       common::sense 3.75
     requirements:
       ExtUtils::MakeMaker 0
+  local-lib-2.000029
+    pathname: H/HA/HAARG/local-lib-2.000029.tar.gz
+    provides:
+      lib::core::only undef
+      local::lib 2.000029
+    requirements:
+      perl 5.006

--- a/author/perl-stripper/perl-stripper/handler.pl
+++ b/author/perl-stripper/perl-stripper/handler.pl
@@ -1,4 +1,4 @@
-use v5.36;
+use v5.42;
 use utf8;
 use lib "$ENV{'LAMBDA_TASK_ROOT'}/local/lib/perl5";
 use lib "$ENV{'LAMBDA_TASK_ROOT'}/local/lib/perl5/aarch64-linux";
@@ -31,5 +31,3 @@ my $func = AWS::Lambda::PSGI->wrap($app);
 sub handle($payload, $context) {
     return $func->($payload);
 }
-
-1;

--- a/author/perl-stripper/template.yaml
+++ b/author/perl-stripper/template.yaml
@@ -11,12 +11,12 @@ Resources:
       Description: Perl Stripper API
       CodeUri: ./perl-stripper/
       Handler: handler.handle
-      Runtime: provided.al2
+      Runtime: provided.al2023
       Architectures: [arm64]
       Timeout: 120
       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-memory-console
       MemorySize: 1769 # -> 1 vCPU
       Layers:
-        - arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-38-runtime-al2-arm64:3
+        - arn:aws:lambda:ap-northeast-1:445285296882:layer:perl-5-42-runtime-al2023-arm64:5
       FunctionUrlConfig:
         AuthType: NONE


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated the Perl runtime requirement to Perl 5.42.
  * Migrated the serverless function to the Amazon Linux 2023–based `provided` runtime.
  * Updated the associated runtime layer to the matching Perl 5.42 AL2023 arm64 layer.
* **Chores**
  * Refreshed build and dependency requirements to support the newer Perl/runtime versions, including the build/update container settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->