### PR TITLE
Update documentation to reflect the correct runtime selection for Amazon Linux 2023

### DIFF
--- a/lib/AWS/Lambda.pm
+++ b/lib/AWS/Lambda.pm
@@ -130,7 +130,7 @@ Create a new function and give it a name and an IAM Role.
 
 =item 3
 
-For the "Runtime" selection, select B<Provide your own bootstrap on Amazon Linux 2>.
+For the "Runtime" selection, select B<Provide your own bootstrap on Amazon Linux 2023>.
 
 =item 4
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Lambda setup instructions to recommend selecting “Provide your own bootstrap on Amazon Linux 2023” instead of the Amazon Linux 2 option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->